### PR TITLE
T8600 Clicking on already open menu item should close mobile navigation

### DIFF
--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -17,6 +17,16 @@ import "./Header.css";
 import PromoLine from "../PromoLine/PromoLine";
 
 const Header = ({ noSticky }) => {
+  const closeMenuOnSameLink = (nextPathName) => {
+    if (typeof window === `undefined`) {
+      return;
+    }
+    const menuTriggerElement = document.getElementById(`menu-sensor`);
+    if (nextPathName === window.location.pathname) {
+      menuTriggerElement.click();
+    }
+  };
+
   return (
     <React.Fragment>
       <div className={`Header ${noSticky ? `Header--no-sticky` : ``}`}>
@@ -39,7 +49,13 @@ const Header = ({ noSticky }) => {
               {NAVIGATION_MAIN_MENU.map((item) => {
                 return (
                   <li key={item.pathname}>
-                    <Link aria-haspopup={!!item.children} to={item.pathname}>
+                    <Link
+                      aria-haspopup={!!item.children}
+                      to={item.pathname}
+                      onClick={() => {
+                        closeMenuOnSameLink(item.pathname);
+                      }}
+                    >
                       {item.title}
                     </Link>
                     {item.children && (
@@ -47,7 +63,14 @@ const Header = ({ noSticky }) => {
                         {item.children.map((subItem) => {
                           return (
                             <li key={subItem.pathname}>
-                              <Link to={subItem.pathname}>{subItem.title}</Link>
+                              <Link
+                                to={subItem.pathname}
+                                onClick={() => {
+                                  closeMenuOnSameLink(subItem.pathname);
+                                }}
+                              >
+                                {subItem.title}
+                              </Link>
                             </li>
                           );
                         })}


### PR DESCRIPTION
Issue https://app.forecast.it/project/P-59/scoping/T8600

# Summary of Changes
1. Create a `closeMenuOnSameLink()` function
2. Add that function to menu & submenu `<Link />` items

# Notes
Gatsby would not redirect you to the same page twice, therefore it
wouldn't re-render and the hidden checkbox would stay checked.
This function fixes that.

# To test locally
- [ ] `npm run develop`
- [ ] http://localhost:8000/bukime-budrus/piliecio-atmintine/
- [ ] Open the **mobile** navigation menu
- [ ] Click on the same link *(in this case 'Piliecio atmintine')*
- [ ] See if the menu closes