### PR TITLE
T8730 External links should be using `<a />` tags

### DIFF
--- a/src/components/CtaCard/CtaCard.js
+++ b/src/components/CtaCard/CtaCard.js
@@ -2,7 +2,7 @@ import * as React from "react";
 import PropTypes from "prop-types";
 
 import "./CtaCard.css";
-import { Link } from "gatsby";
+import Link from "../Link";
 
 const CtaCard = ({ children, title, iconHandle, link, ...props }) => {
   return (

--- a/src/components/Link/Link.js
+++ b/src/components/Link/Link.js
@@ -1,0 +1,43 @@
+// https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-link/#reminder-use-link-only-for-internal-links
+
+import React from "react";
+import { Link as GatsbyLink } from "gatsby";
+import PropTypes from "prop-types";
+
+// Since DOM elements <a> cannot receive activeClassName
+// and partiallyActive, destructure the prop here and
+// pass it only to GatsbyLink
+const Link = ({ children, to, activeClassName, partiallyActive, ...other }) => {
+  // Tailor the following test to your environment.
+  // This example assumes that any internal link (intended for Gatsby)
+  // will start with exactly one slash, and that anything else is external.
+  const internal = /^\/(?!\/)/.test(to);
+
+  // Use Gatsby Link for internal links, and <a> for others
+  if (internal) {
+    return (
+      <GatsbyLink
+        to={to}
+        activeClassName={activeClassName}
+        partiallyActive={partiallyActive}
+        {...other}
+      >
+        {children}
+      </GatsbyLink>
+    );
+  }
+  return (
+    <a href={to} {...other}>
+      {children}
+    </a>
+  );
+};
+
+Link.propTypes = {
+  children: PropTypes.node,
+  to: PropTypes.string,
+  activeClassName: PropTypes.string,
+  partiallyActive: PropTypes.bool,
+};
+
+export default Link;

--- a/src/components/Link/index.js
+++ b/src/components/Link/index.js
@@ -1,0 +1,1 @@
+export { default } from "./Link";


### PR DESCRIPTION
Issue https://app.forecast.it/project/P-59/workflow/T8730

# Summary of Changes
1. Create a new `<Link />` component that acts as a wrapper for Gatsby's `<Link />`
   - [Taken from the example here](https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-link/#reminder-use-link-only-for-internal-links)
2. Replace `<CtaCard />` component's `<Link />` with the newly created wrapper component
   - Ideally every link should be using the wrapper component, but since I'm not 100% sure on the credibility of it, I'd like to first test it out and see if it works flawlessly.

# Notes
Gatsby's `<Link />` component uses pre-loading for the fastest loading performance, therefore it is **not recommended** to be used with external links.
[Can read more here](https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-link/)

Without this wrapper component you get errors like this: *(and even more on pages that have several links)*
![image](https://user-images.githubusercontent.com/69549795/159897715-86db8d2f-852e-43a7-b39f-8befbad70437.png)

# To test locally
- [ ] `npm run develop`
- [ ] https://localhost:8000
- [ ] Open up the DevTools console
- [ ] Navigate between homepage & other pages
- [ ] See if the button on homepage "Pasiūlyk pagalbą ukrainiečiams" throws any errors in the console