### PR TITLE
T8672 Sort events by date (new first)

### DIFF
--- a/src/pages/protesto-formos/renginiai.js
+++ b/src/pages/protesto-formos/renginiai.js
@@ -29,6 +29,13 @@ const Page = ({ data }) => {
     };
   });
 
+  const sortedEvents = events.slice().sort((a, b) => {
+    const dateA = new Date(a.startDate);
+    const dateB = new Date(b.startDate);
+
+    return dateA - dateB;
+  });
+
   return (
     <Layout pagePath="/protesto-formos/renginiai/">
       {(!content || !content.title) && <Title>Renginiai</Title>}
@@ -57,7 +64,7 @@ const Page = ({ data }) => {
 
       <Constraint>
         <EventCardList>
-          {events.map((event, i) => {
+          {sortedEvents.map((event, i) => {
             return (
               <EventCard
                 key={i}

--- a/src/pages/protesto-formos/renginiai.js
+++ b/src/pages/protesto-formos/renginiai.js
@@ -29,13 +29,6 @@ const Page = ({ data }) => {
     };
   });
 
-  const sortedEvents = events.slice().sort((a, b) => {
-    const dateA = new Date(a.startDate);
-    const dateB = new Date(b.startDate);
-
-    return dateA - dateB;
-  });
-
   return (
     <Layout pagePath="/protesto-formos/renginiai/">
       {(!content || !content.title) && <Title>Renginiai</Title>}
@@ -64,7 +57,7 @@ const Page = ({ data }) => {
 
       <Constraint>
         <EventCardList>
-          {sortedEvents.map((event, i) => {
+          {events.map((event, i) => {
             return (
               <EventCard
                 key={i}
@@ -109,7 +102,7 @@ export const query = graphql`
     }
     events: allFile(
       filter: { sourceInstanceName: { eq: "events" } }
-      sort: { fields: childMarkdownRemark___frontmatter___weight }
+      sort: { fields: childMarkdownRemark___frontmatter___startDate }
     ) {
       edges {
         node {


### PR DESCRIPTION
Issue https://app.forecast.it/project/P-59/workflow/T8672

# Summary of Changes
~~1. Create a new constant `sortedEvents` that takes a shallow copy of `events` and sorts them by date~~
~~2. Replace `events.map()` with `sortedEvents.map()`~~
3. Change GraphQL query to sort by `startDate`

# Notes
~~Not sure if there should be any safety checks added, like `if (events)` or maybe a `useEffect(() => {...}, [events])`~~
Never done anything similar with GraphQL, not sure if this is the correct way

# Screenshots
## Before
![image](https://user-images.githubusercontent.com/69549795/159908083-3dff8cc9-c33c-4a84-be73-48fc933e730c.png)

## After
![image](https://user-images.githubusercontent.com/69549795/159908041-c40b2804-2b3d-4759-bf03-34b7f0388435.png)

# To test
- [ ] Open up the events page
   - http://localhost:8000/protesto-formos/renginiai *(local)*
   - https://suukraina.lt/protesto-formos/renginiai/
- [ ] See if the events are sorted by date from earliest to latest