### PR TITLE
T8670 Add sidebar overlay to `HelpSearch`

### DIFF
--- a/src/components/HelpSearch/HelpSearch.css
+++ b/src/components/HelpSearch/HelpSearch.css
@@ -149,10 +149,31 @@
     position: fixed;
     transition: height 0.2s ease;
     width: calc(100% - var(--s__main-padding));
+    z-index: 1002; /* 1 above `&__sidebar-overlay` */
+  }
+
+  &__sidebar-overlay {
+    background: rgb(0 0 0 / 20%);
+    height: 100%;
+    left: 0;
+    opacity: 0;
+    pointer-events: none;
+    position: fixed;
+    top: 0;
+    transition: opacity 0.2s ease;
+    width: 100%;
     z-index: 1001; /* 1 above `.Header` */
   }
 
-  #filters-sensor:checked + &__filters-trigger + &__sidebar {
+  #filters-sensor:checked + &__filters-trigger + &__sidebar-overlay {
+    opacity: 1;
+    pointer-events: all;
+  }
+
+  #filters-sensor:checked
+    + &__filters-trigger
+    + &__sidebar-overlay
+    + &__sidebar {
     height: 80vh;
     overflow: auto;
   }
@@ -278,7 +299,14 @@
       width: auto;
     }
 
-    #filters-sensor:checked + &__filters-trigger + &__sidebar {
+    &__sidebar-overlay {
+      display: none;
+    }
+
+    #filters-sensor:checked
+      + &__filters-trigger
+      + &__sidebar-overlay
+      + &__sidebar {
       height: auto;
       overflow: visible;
     }

--- a/src/components/HelpSearch/HelpSearch.js
+++ b/src/components/HelpSearch/HelpSearch.js
@@ -546,6 +546,10 @@ const HelpSearch = () => {
               text={TRANSLATIONS.refinements.panelTitle[resultsLang]}
             />
           </label>
+          <label
+            className="HelpSearch__sidebar-overlay"
+            htmlFor="filters-sensor"
+          />
           <div className="HelpSearch__sidebar">
             <p className="HelpSearch__sidebar-title">
               {TRANSLATIONS.refinements.panelTitle[resultsLang]}


### PR DESCRIPTION
There's no overlay when displaying search-filters -- it should close/collapse the filters when clicked.

# Summary of Changes

1. Overlay added.

# Screenshots

## Desktop

## Mobile

# To test locally

- [ ] Open the search page (`/pagalba`);
- [ ] Switch to narrow layout;
- [ ] Open filters;
- [ ] A semi-transparent overlay behind the filters panel should be visible;
- [ ] When the semi-transparent overlay is clicked, the filters panel should close/collapse/disappear;
