### PR TITLE
T8865 Alternative Footer on FAQ & Search pages

### DIFF
--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -1,4 +1,5 @@
 import * as React from "react";
+import PropTypes from "prop-types";
 import { Link } from "gatsby";
 
 // Styles.
@@ -23,31 +24,33 @@ import SuUkrainaWhite from "../../images/logos/su-ukraina--secondary.svg";
 import Adapt from "../../images/logos/adapt.svg";
 import LaisvesTv from "../../images/logos/laisves-tv.svg";
 
-const Footer = () => {
+const Footer = ({ altFooter }) => {
   return (
     <footer className="Footer">
       <Constraint>
-        <div className="Footer__cta-section">
-          <div className="Footer__cta-section-title">
-            Kiekvienas veiksmas svarbus
+        {!altFooter && (
+          <div className="Footer__cta-section">
+            <div className="Footer__cta-section-title">
+              Kiekvienas veiksmas svarbus
+            </div>
+            <div className="Footer__cta-section-actions">
+              <Button
+                to={PATH_HOW_TO_DONATE}
+                startIcon={ICON_DONATE}
+                color={`secondary`}
+              >
+                {TEXT_WANT_TO_DONATE}
+              </Button>
+              <Button
+                to={PATH_HOW_TO_VOLUNTEER}
+                startIcon={ICON_VOLUNTEER}
+                color={`secondary`}
+              >
+                {TEXT_WANT_TO_VOLUNTEER}
+              </Button>
+            </div>
           </div>
-          <div className="Footer__cta-section-actions">
-            <Button
-              to={PATH_HOW_TO_DONATE}
-              startIcon={ICON_DONATE}
-              color={`secondary`}
-            >
-              {TEXT_WANT_TO_DONATE}
-            </Button>
-            <Button
-              to={PATH_HOW_TO_VOLUNTEER}
-              startIcon={ICON_VOLUNTEER}
-              color={`secondary`}
-            >
-              {TEXT_WANT_TO_VOLUNTEER}
-            </Button>
-          </div>
-        </div>
+        )}
         <div className="Footer__menus">
           <p>
             <img
@@ -61,11 +64,17 @@ const Footer = () => {
           <p>
             <nav className="Footer__nav" aria-label="Poraštės navigacija">
               <ul className="Footer__menu">
+                {!altFooter && (
+                  <li>
+                    <Link to="/apie-mus/">Apie mus</Link>
+                  </li>
+                )}
                 <li>
-                  <Link to="/apie-mus/">Apie mus</Link>
-                </li>
-                <li>
-                  <Link to="/privatumo-politika/">Privatumo politika</Link>
+                  <Link to="/privatumo-politika/">
+                    {altFooter
+                      ? `Політика конфіденційності`
+                      : `Privatumo politika`}
+                  </Link>
                 </li>
               </ul>
             </nav>
@@ -76,7 +85,11 @@ const Footer = () => {
             2022 | <span title="Героям слава!">Слава Україні!</span>
           </p>
           <p className="Footer__partners">
-            <span className="Footer__partners-intro">Puslapį koordinuoja:</span>
+            <span className="Footer__partners-intro">
+              {altFooter
+                ? `Внесла внесок на сторінку:`
+                : `Puslapį koordinuoja:`}
+            </span>
             {` `}
             <a
               href="https://adaptagency.com/adapt-lithuania"
@@ -99,6 +112,10 @@ const Footer = () => {
       </Constraint>
     </footer>
   );
+};
+
+Footer.propTypes = {
+  altFooter: PropTypes.bool,
 };
 
 export default Footer;

--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -1,6 +1,7 @@
 import * as React from "react";
 import PropTypes from "prop-types";
 import { Link } from "gatsby";
+import { useLocation } from "@reach/router";
 
 // Styles.
 import "./Footer.css";
@@ -19,12 +20,18 @@ import {
   TEXT_WANT_TO_VOLUNTEER,
 } from "../../constants/Footer";
 
+// Helpers
+import { isUkrainianPage } from "../../helpers/handlers";
+
 // SVGs.
 import SuUkrainaWhite from "../../images/logos/su-ukraina--secondary.svg";
 import Adapt from "../../images/logos/adapt.svg";
 import LaisvesTv from "../../images/logos/laisves-tv.svg";
 
-const Footer = ({ altFooter }) => {
+const Footer = () => {
+  const location = useLocation();
+  const altFooter = isUkrainianPage(location.pathname);
+
   return (
     <footer className="Footer">
       <Constraint>

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,6 +1,7 @@
 import * as React from "react";
 import PropTypes from "prop-types";
 import { Link } from "gatsby";
+import { useLocation } from "@reach/router";
 
 // Components.
 import Constraint from "../Constraint";
@@ -15,11 +16,17 @@ import {
   NAVIGATION_MAIN_MENU_ALT,
 } from "../../constants/Navigation";
 
+// Helpers
+import { isUkrainianPage } from "../../helpers/handlers";
+
 // Style.
 import "./Header.css";
 
-const Header = ({ noSticky, altHeader }) => {
+const Header = ({ noSticky }) => {
   const [headerHeight, setHeaderHeight] = React.useState(null);
+  const location = useLocation();
+  const altHeader = isUkrainianPage(location.pathname);
+
   const headerRef = React.useRef(null);
   React.useLayoutEffect(() => {
     const resetHeaderHeight = () => {

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -23,7 +23,7 @@ const Layout = ({ children, noStickyHeader, pagePath }) => {
   const location = useLocation();
   const splitPathname = location.pathname.split(`/`);
 
-  const altHeader = [
+  const altLayout = [
     `pagalbos-paieska`,
     `refugee-guide`,
     `help-search`,
@@ -43,8 +43,8 @@ const Layout = ({ children, noStickyHeader, pagePath }) => {
 
   return (
     <div className="Layout">
-      <Header noSticky={noStickyHeader} altHeader={altHeader} />
-      {!altHeader && (
+      <Header noSticky={noStickyHeader} altHeader={altLayout} />
+      {!altLayout && (
         <PromoLine
           title="Вся важлива інформація для громадян України"
           titleLink={NAVIGATION_ITEM_HELP.pathname}
@@ -77,7 +77,7 @@ const Layout = ({ children, noStickyHeader, pagePath }) => {
         </Constraint>
       </Section>
 
-      <Footer />
+      <Footer altFooter={altLayout} />
     </div>
   );
 };

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -17,18 +17,13 @@ import {
   NAVIGATION_ITEM_REFUGEE_GUIDE,
 } from "../../constants/Navigation";
 
+// Helpers
+import { isUkrainianPage } from "../../helpers/handlers";
+
 import "./Layout.css";
 
 const Layout = ({ children, noStickyHeader, pagePath }) => {
   const location = useLocation();
-  const splitPathname = location.pathname.split(`/`);
-
-  const altLayout = [
-    `pagalbos-paieska`,
-    `refugee-guide`,
-    `help-search`,
-    `privacy-policy`,
-  ].includes(splitPathname[1]);
 
   function RenderForm() {
     const refugeeGuidePath = `refugee-guide`;
@@ -43,8 +38,8 @@ const Layout = ({ children, noStickyHeader, pagePath }) => {
 
   return (
     <div className="Layout">
-      <Header noSticky={noStickyHeader} altHeader={altLayout} />
-      {!altLayout && (
+      <Header noSticky={noStickyHeader} />
+      {!isUkrainianPage(location.pathname) && (
         <PromoLine
           title="Вся важлива інформація для громадян України"
           titleLink={NAVIGATION_ITEM_HELP.pathname}
@@ -77,7 +72,7 @@ const Layout = ({ children, noStickyHeader, pagePath }) => {
         </Constraint>
       </Section>
 
-      <Footer altFooter={altLayout} />
+      <Footer />
     </div>
   );
 };

--- a/src/helpers/handlers.js
+++ b/src/helpers/handlers.js
@@ -28,3 +28,17 @@ export const handlePath = (pseudoLink) => {
       return `/refugee-guide/`;
   }
 };
+
+export const isUkrainianPage = (pathname) => {
+  // pathname is expected as location.pathname from useLocation()
+  const splitPathname = pathname.split(`/`);
+
+  const isUkrainianPathname = [
+    `pagalbos-paieska`,
+    `refugee-guide`,
+    `help-search`,
+    `privacy-policy`,
+  ].includes(splitPathname[1]);
+
+  return isUkrainianPathname;
+};


### PR DESCRIPTION
<!--
Creating the PR.
- Fill the template, add/remove sections as needed.
-->

<!-- Link to issue on Forecast -->

Issue https://app.forecast.it/project/P-59/workflow/T8865
Design https://www.figma.com/file/SbHEfVWgFSozSl1m5oJdmd/Suukraina.lt?node-id=0%3A1

<!-- If needed, link to design -->

# Summary of Changes

1. Disable `Footer__cta-section` on alternative footer
2. Disable `/apie-mus/` link on alternative footer
3. Translate privacy policy on alternative footer
4. Translate page coordinators on alternative footer

# Screenshots

## Wide layout
![image](https://user-images.githubusercontent.com/69549795/162446677-3df7032f-7240-4fab-b844-bc82a291c14c.png)

## Narrow layout
![image](https://user-images.githubusercontent.com/69549795/162446721-919baa1c-61e5-4bb4-aca7-9492a8a24670.png)

# To test

- [ ] Go to `/refugee-guide` or `/help-search/`
- [ ] See if footer looks as expected
