### PR TITLE
T8663 use constants for PromoLine and HeroBanner navigation

### DIFF
--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -123,9 +123,8 @@
       }
     }
 
-    /* @TODO solve the problem with !important */
-    &__help-btn {
-      display: flex !important;
+    &-help-btn {
+      display: flex;
       max-width: 16rem;
     }
   }
@@ -151,13 +150,16 @@
     }
 
     a {
-      display: block;
       padding: calc(var(--s__unit) * 2);
       transition: color 0.2s ease-in-out;
       color: black;
 
       &.Button {
         color: white;
+      }
+
+      &:not(.Button) {
+        display: block;
       }
 
       &:hover {

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -14,6 +14,7 @@ import Logo from "../../images/logos/su-ukraina--original.svg";
 import {
   NAVIGATION_MAIN_MENU,
   NAVIGATION_MAIN_MENU_ALT,
+  NAVIGATION_EXTERNAL_LINK_PROVIDE_HELP,
 } from "../../constants/Navigation";
 
 // Helpers
@@ -126,14 +127,14 @@ const Header = ({ noSticky }) => {
             {altHeader && (
               <li>
                 <Button
-                  className="Header__menu__help-btn"
+                  className="Header__menu-help-btn"
                   startIcon={`edit`}
-                  href="https://0rs0r9mdix1.typeform.com/to/QXLxIUjt"
+                  href={NAVIGATION_EXTERNAL_LINK_PROVIDE_HELP.url}
                   color={`primary`}
                   target="_blank"
                   rel="noopener"
                 >
-                  Noriu suteikti pagalbą
+                  {NAVIGATION_EXTERNAL_LINK_PROVIDE_HELP.title}
                 </Button>
               </li>
             )}

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -14,7 +14,7 @@ import Button from "../Button";
 // Constants.
 import {
   NAVIGATION_ITEM_HELP,
-  NAVIGATION_ITEM_REFUGEE_GUIDE,
+  NAVIGATION_MAIN_MENU_ALT,
 } from "../../constants/Navigation";
 
 // Helpers
@@ -44,24 +44,17 @@ const Layout = ({ children, noStickyHeader, pagePath }) => {
           title="Вся важлива інформація для громадян України"
           titleLink={NAVIGATION_ITEM_HELP.pathname}
         >
-          <Button
-            endIcon={`arrow-blue`}
-            to={NAVIGATION_ITEM_REFUGEE_GUIDE.pathname}
-            color={`secondary`}
-            target="_blank"
-            rel="noopener"
-          >
-            Інформація
-          </Button>
-          <Button
-            endIcon={`arrow-blue`}
-            to={NAVIGATION_ITEM_HELP.pathname}
-            color={`secondary`}
-            target="_blank"
-            rel="noopener"
-          >
-            Послуги
-          </Button>
+          {NAVIGATION_MAIN_MENU_ALT.map((item) => (
+            <Button
+              endIcon={`arrow-blue`}
+              to={item.pathname}
+              color={`secondary`}
+              target="_blank"
+              rel="noopener"
+            >
+              {item.altTitle || item.title}
+            </Button>
+          ))}
         </PromoLine>
       )}
       <main>{children}</main>

--- a/src/constants/Navigation.js
+++ b/src/constants/Navigation.js
@@ -7,11 +7,13 @@ export const NAVIGATION_ITEM_HOW_CAN_I_HELP = {
 export const NAVIGATION_ITEM_HOW_CAN_I_HELP_DONATION_LITHUANIA = {
   pathname: `/kaip-galiu-padeti/aukojimas/lietuvoje/`,
   title: `Aukojimas`,
+  iconHandle: `donate`,
 };
 
 export const NAVIGATION_ITEM_HOW_CAN_I_HELP_VOLUNTEER = {
   pathname: `/kaip-galiu-padeti/savanoryste/`,
   title: `Savanorystė`,
+  iconHandle: `volunteer`,
 };
 
 export const NAVIGATION_ITEM_PROTEST_FORMS = {
@@ -58,13 +60,13 @@ export const NAVIGATION_ITEM_BE_VIGILANT_SCAMS_AND_MISINFORMATION = {
 export const NAVIGATION_ITEM_HELP = {
   pathname: `/help-search/`,
   title: `Знайти довідку`,
-  altTitle: `Знайти довідку`,
+  altTitle: `Послуги`,
 };
 
 export const NAVIGATION_ITEM_REFUGEE_GUIDE = {
   pathname: `/refugee-guide/`,
   title: `Важлива інформація`,
-  altTitle: `Важлива інформація`,
+  altTitle: `Інформація`,
 };
 
 // Navigation of how can I help page.
@@ -112,3 +114,10 @@ export const NAVIGATION_MAIN_MENU_ALT = [
   NAVIGATION_ITEM_HELP,
   NAVIGATION_ITEM_REFUGEE_GUIDE,
 ];
+
+// External links.
+export const NAVIGATION_EXTERNAL_LINK_PROVIDE_HELP = {
+  url: `https://0rs0r9mdix1.typeform.com/to/QXLxIUjt`,
+  title: `Noriu suteikti pagalbą`,
+  iconHandle: `ua-flag`,
+};

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -17,9 +17,11 @@ import { StaticImage } from "gatsby-plugin-image";
 
 // Constants.
 import {
-  NAVIGATION_BE_VIGILANT,
-  NAVIGATION_ITEM_HELP,
+  NAVIGATION_HOW_CAN_I_HELP,
+  NAVIGATION_EXTERNAL_LINK_PROVIDE_HELP,
   NAVIGATION_ITEM_REFUGEE_GUIDE,
+  NAVIGATION_MAIN_MENU_ALT,
+  NAVIGATION_BE_VIGILANT,
 } from "../constants/Navigation";
 import PromoLine from "../components/PromoLine";
 
@@ -72,20 +74,17 @@ const Page = ({ data }) => {
         />
         <HeroBanner title="Su Ukraina iki pergalės!">
           <Constraint className="HeroBanner__inner">
+            {NAVIGATION_HOW_CAN_I_HELP.map((item) => (
+              <CtaCard
+                title={item.title}
+                link={item.pathname}
+                iconHandle={item.iconHandle}
+              />
+            ))}
             <CtaCard
-              title="Aukojimas"
-              link="/kaip-galiu-padeti/aukojimas/lietuvoje/"
-              iconHandle="donate"
-            />
-            <CtaCard
-              title="Savanorystė"
-              link="/kaip-galiu-padeti/savanoryste/"
-              iconHandle="volunteer"
-            />
-            <CtaCard
-              title="Pasiūlyk pagalbą ukrainiečiams"
-              link="https://0rs0r9mdix1.typeform.com/to/QXLxIUjt"
-              iconHandle="ua-flag"
+              title={NAVIGATION_EXTERNAL_LINK_PROVIDE_HELP.title}
+              link={NAVIGATION_EXTERNAL_LINK_PROVIDE_HELP.url}
+              iconHandle={NAVIGATION_EXTERNAL_LINK_PROVIDE_HELP.iconHandle}
               target="_blank"
             />
           </Constraint>
@@ -97,24 +96,17 @@ const Page = ({ data }) => {
           titleLink={NAVIGATION_ITEM_REFUGEE_GUIDE.pathname}
           modifier="big"
         >
-          <Button
-            endIcon={`arrow-blue`}
-            to={NAVIGATION_ITEM_REFUGEE_GUIDE.pathname}
-            color={`secondary`}
-            target="_blank"
-            rel="noopener"
-          >
-            Інформація
-          </Button>
-          <Button
-            endIcon={`arrow-blue`}
-            to={NAVIGATION_ITEM_HELP.pathname}
-            color={`secondary`}
-            target="_blank"
-            rel="noopener"
-          >
-            Послуги
-          </Button>
+          {NAVIGATION_MAIN_MENU_ALT.map((item) => (
+            <Button
+              endIcon={`arrow-blue`}
+              to={item.pathname}
+              color={`secondary`}
+              target="_blank"
+              rel="noopener"
+            >
+              {item.altTitle || item.title}
+            </Button>
+          ))}
         </PromoLine>
       </Section>
       {/* <Section className="ProtestFormsSection">


### PR DESCRIPTION
Issue https://app.forecast.it/project/P-59/workflow/T8663

# Summary of Changes

1. Use constant `NAVIGATION_MAIN_MENU_ALT` for PromoLine navigation
2. Use constant `NAVIGATION_HOW_CAN_I_HELP` for HeroBanner navigation
3. Remove` !important` from header.scss
4. Add `NAVIGATION_EXTERNAL_LINK_PROVIDE_HELP` constant to specify this URL: https://0rs0r9mdix1.typeform.com/to/QXLxIUjt (Noriu suteikti pagalbą)

Warning! This will result in reversed order of PromoLine navigation. But I find this way better since it matches the navigation order in the pages, that they are linking to:
![Screenshot 2022-04-08 at 19 12 18](https://user-images.githubusercontent.com/8254961/162481392-52702116-76c5-4889-948c-10dfa8d24e34.png)
