### PR TITLE
T8663 update nav button color CSS rule placement

### DIFF
--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -154,16 +154,16 @@
       transition: color 0.2s ease-in-out;
       color: black;
 
-      &.Button {
-        color: white;
-      }
-
       &:not(.Button) {
         display: block;
       }
 
       &:hover {
         color: var(--c__primary);
+      }
+
+      &.Button {
+        color: white;
       }
     }
   }


### PR DESCRIPTION
Issue: Button link becomes blue on hover

# Summary of Changes

1. Updated CSS rule order, so Button link color won't change on hover.

![image](https://user-images.githubusercontent.com/8254961/162698293-6d997179-1328-4771-9665-b11f049be17a.png)
