### PR TITLE
T000 Change active menu item border

### DIFF
--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -113,12 +113,16 @@
       &.is-active {
         > a {
           display: inline-block;
+          position: relative;
 
           &::after {
-            border-bottom: 2px solid var(--c__primary);
+            background-color: var(--c__primary);
+            bottom: 0;
             content: "";
             display: block;
-            margin-top: 3px;
+            height: 2px;
+            position: absolute;
+            width: calc(100% - var(--s__main-padding) * 2);
           }
         }
       }

--- a/src/components/LanguageSwitch/LanguageSwitch.css
+++ b/src/components/LanguageSwitch/LanguageSwitch.css
@@ -13,7 +13,7 @@
     align-items: center;
     cursor: pointer;
     display: flex;
-    padding-bottom: 0.5rem;
+    padding: 0.5rem 0;
     transition: box-shadow 0.2s ease;
 
     &:hover {


### PR DESCRIPTION
<!--
Creating the PR.
- Fill the template, add/remove sections as needed.
-->

<!-- Link to issue on Forecast -->


<!-- If needed, link to design -->

# Summary of Changes

1. Remove `border-bottom` property from `::after` element
2. Make the `::after` element an absolute element with 2px height

# Notes

The previous iteration of `border-bottom: 2px;` would increase the header height by 2px

# Screenshots
![image](https://user-images.githubusercontent.com/69549795/163571030-dc80ab08-96eb-4dba-bc08-42ad81960d0d.png)


# To test

- [ ] Swap between homepage & any of the nav pages
- [ ] See if header height changes