### PR TITLE
T000 Add padding animation to FaqNavCollapsible

### DIFF
--- a/src/components/Faq/FaqNavCollapsible.css
+++ b/src/components/Faq/FaqNavCollapsible.css
@@ -9,7 +9,7 @@
   overflow: hidden;
   padding: 0;
   position: fixed;
-  transition: height 0.2s ease;
+  transition: height 0.2s ease, padding 0.2s ease;
   width: calc(100% - (var(--s__main-padding) * 2));
   z-index: 1002; /* 1 above faqnav-overlay */
 


### PR DESCRIPTION
# Summary of Changes

1. Add padding animation to FaqNavCollapsible

# Notes

Previously without the animation it looked jarring when you close the FaqNav and instantly
set padding to zero.

# To test

- [ ] Go to `/refugee-guide/`  on mobile
- [ ] Open any subpage
- [ ] Open the menu & see if it looks and works as expected
