### PR TITLE
T9043 Stop toggling LangSwitch visibiility on wide

### DIFF
--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -262,6 +262,10 @@
       overflow: visible;
     }
 
+    #menu-sensor:checked ~ .LanguageSwitch {
+      display: block;
+    }
+
     &__content {
       justify-content: flex-start;
     }


### PR DESCRIPTION
<!--
Creating the PR.
- Fill the template, add/remove sections as needed.
-->

<!-- Link to issue on Forecast -->

Issue https://app.forecast.it/project/P-59/workflow/T9043

<!-- If needed, link to design -->

# Summary of Changes

1. Add `display: block` on wide layout when menu-sensor is checked

# Notes

Not sure if this is the correct way to solve it, but seems like it fixed it.

# To test

- [ ] Go to page on wide layout
- [ ] Keep clicking the same menu navigation link
- [ ] See if langswitch disappears
