### PR TITLE
T9110 Add sliding navigation to wide layout

### DIFF
--- a/src/components/Constraint/Constraint.css
+++ b/src/components/Constraint/Constraint.css
@@ -8,10 +8,4 @@
   &--contact-chip-sections {
     padding: 0;
   }
-
-  @media (min-width: 66rem) {
-    &--contact-chip-sections {
-      padding: var(--constraint-padding);
-    }
-  }
 }

--- a/src/components/ContactChip/ContactChip.css
+++ b/src/components/ContactChip/ContactChip.css
@@ -3,7 +3,11 @@
   display: flex;
   justify-content: space-between;
   margin: var(--s__main-padding) 0;
-  padding: var(--s__main-padding) 0;
+  padding: var(--s__main-padding);
+
+  &:hover {
+    background-color: var(--c__neutral-10);
+  }
 
   &__actions {
     display: flex;
@@ -27,12 +31,9 @@
       }
 
       &:hover,
-      &:active {
-        background: #545454;
-      }
-
+      &:active,
       &:focus {
-        background: #545454;
+        background: var(--c__primary);
       }
     }
 
@@ -72,12 +73,5 @@
 
   & + & {
     margin-top: calc(var(--s__main-padding) * -1);
-  }
-
-  @media (min-width: 66rem) {
-    &__actions > a {
-      height: 36px;
-      width: 36px;
-    }
   }
 }

--- a/src/components/ContactChip/ContactChip.css
+++ b/src/components/ContactChip/ContactChip.css
@@ -1,12 +1,12 @@
 .ContactChip {
-  border-bottom: 1px solid var(--c__neutral-10);
+  border-bottom: 1px solid var(--c__alt-bg);
   display: flex;
   justify-content: space-between;
   margin: var(--s__main-padding) 0;
   padding: var(--s__main-padding);
 
   &:hover {
-    background-color: var(--c__neutral-10);
+    background-color: var(--c__alt-bg);
   }
 
   &__actions {

--- a/src/components/ContactChipSections/ContactChipSections.css
+++ b/src/components/ContactChipSections/ContactChipSections.css
@@ -21,10 +21,6 @@
     padding: 0;
   }
 
-  &__articles {
-    padding: 0 var(--s__main-padding);
-  }
-
   &__icon {
     content: "";
     display: block;
@@ -39,51 +35,17 @@
 
     &--people {
       background: var(--c__primary);
-      height: 24px;
-      margin-right: 10px;
       mask-image: url("../../images/icons/people.svg");
-      width: 24px;
     }
 
     &--institutions {
       background: var(--c__primary);
-      height: 24px;
-      margin-right: 10px;
       mask-image: url("../../images/icons/institutions.svg");
-      width: 24px;
     }
 
     &--foreign {
       background: var(--c__primary);
-      height: 24px;
-      margin-right: 10px;
       mask-image: url("../../images/icons/web.svg");
-      width: 24px;
-    }
-  }
-
-  @media (min-width: 66rem) {
-    align-items: flex-start;
-    display: flex;
-    gap: var(--s__alt-padding);
-
-    > * {
-      flex: 1;
-    }
-
-    &__container {
-      border-radius: var(--s__alt-border-radius);
-      box-shadow: 0 3px 20px -1px rgb(0 0 0 / 10%);
-    }
-
-    &__title-wrapper {
-      border-radius: var(--s__alt-border-radius);
-      border-bottom-left-radius: 0;
-      border-bottom-right-radius: 0;
-    }
-
-    .SlidingNavigation {
-      display: none;
     }
   }
 }

--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -193,8 +193,7 @@
   }
 
   #menu-sensor:checked + &__menu-trigger + &__nav {
-    /* 70px -- magic number. height of header */
-    height: calc(100vh - 70px);
+    height: calc(100vh - var(--header-height));
     overflow: auto;
   }
 

--- a/src/components/SlidingNavigation/SlidingNavigation.css
+++ b/src/components/SlidingNavigation/SlidingNavigation.css
@@ -1,5 +1,5 @@
 .SlidingNavigation {
-  background: var(--c__neutral-12);
+  background: var(--c__main-bg);
   display: flex;
   overflow-x: auto;
   position: sticky;


### PR DESCRIPTION
# Summary of Changes

1. Remove breakpoint style changes;
1. Add hover state for contact chip;
1. Change contact chip icons hover/active/focus color;
1. Move padding from articles container to contact chip;
1. Clean up repeating code.

# Notes
## To do
- [ ] Improve keyboard navigation

# Screenshots
## Wide layout
![image](https://user-images.githubusercontent.com/69549795/168553879-d71c4f1e-8e48-403a-b4ea-3e6887c2590f.png)
![image](https://user-images.githubusercontent.com/69549795/168553957-56dc3418-4177-4b84-bf77-ea8921afb3a3.png)

## Narrow layout
![image](https://user-images.githubusercontent.com/69549795/168554005-d43a9eaa-6cb2-449d-9c44-2f1bf2836ef6.png)
![image](https://user-images.githubusercontent.com/69549795/168554037-30dceebd-c784-4c24-ad75-28c227cfd975.png)

# To test

- [ ] Go to `/patikimi-saltiniai`
- [ ] See if it works & looks as expected
