### PR TITLE
T000 Icon improvements

### DIFF
--- a/src/components/Button/Button.css
+++ b/src/components/Button/Button.css
@@ -90,163 +90,16 @@
     }
   }
 
-  &__icon {
-    &::before {
-      background: #fff;
-      content: "";
-      display: block;
-      height: 20px;
-      mask-position: center;
-      mask-repeat: no-repeat;
-      mask-size: contain;
-      position: relative;
-      width: 20px;
-    }
-
-    &--end {
-      &::before {
-        margin-left: 10px;
-      }
-    }
-
-    &--start {
-      &::before {
-        margin-right: 10px;
-      }
-    }
-
-    &--donate {
-      &::before {
-        background: #3f51b5;
-        mask-image: url("../../images/icons/donate.svg");
-      }
-    }
-
-    &--volunteer {
-      &::before {
-        background: #3f51b5;
-        mask-image: url("../../images/icons/volunteer.svg");
-      }
-    }
-
-    &--arrow-white {
-      &::before {
-        mask-image: url("../../images/icons/arrow-white.svg");
-      }
-    }
-
-    &--arrow-blue {
-      &::before {
-        background: #3f51b5;
-        mask-image: url("../../images/icons/arrow-blue.svg");
-      }
-    }
-
-    &--edit {
-      &::before {
-        mask-image: url("../../images/icons/edit.svg");
-      }
-    }
-
-    &--brain {
-      &::before {
-        mask-image: url("../../images/icons/brain.svg");
-      }
-    }
-
-    &--briefcase {
-      &::before {
-        mask-image: url("../../images/icons/briefcase.svg");
-      }
-    }
-
-    &--building-columns {
-      &::before {
-        mask-image: url("../../images/icons/building-columns.svg");
-      }
-    }
-
-    &--bus-simple {
-      &::before {
-        mask-image: url("../../images/icons/bus-simple.svg");
-      }
-    }
-
-    &--child-reaching {
-      &::before {
-        mask-image: url("../../images/icons/child-reaching.svg");
-      }
-    }
-
-    &--coins {
-      &::before {
-        mask-image: url("../../images/icons/coins.svg");
-      }
-    }
-
-    &--hands-holding-heart {
-      &::before {
-        mask-image: url("../../images/icons/hands-holding-heart.svg");
-      }
-    }
-
-    &--house {
-      &::before {
-        mask-image: url("../../images/icons/house.svg");
-      }
-    }
-
-    &--key-skeleton {
-      &::before {
-        mask-image: url("../../images/icons/key-skeleton.svg");
-      }
-    }
-
-    &--mobile-screen-button {
-      &::before {
-        mask-image: url("../../images/icons/mobile-screen-button.svg");
-      }
-    }
-
-    &--parachute-box {
-      &::before {
-        mask-image: url("../../images/icons/parachute-box.svg");
-      }
-    }
-
-    &--paw {
-      &::before {
-        mask-image: url("../../images/icons/paw.svg");
-      }
-    }
-
-    &--phone {
-      &::before {
-        mask-image: url("../../images/icons/phone.svg");
-      }
-    }
-
-    &--suitcase-medical {
-      &::before {
-        mask-image: url("../../images/icons/suitcase-medical.svg");
-      }
-    }
-
-    &--user-police {
-      &::before {
-        mask-image: url("../../images/icons/user-police.svg");
-      }
-    }
+  .Icon {
+    --icon-size: 20px;
   }
 
   &--active {
     background: var(--c__secondary);
     color: var(--c__primary);
 
-    .Button__icon {
-      &::before {
-        background: var(--c__primary);
-      }
+    .Icon {
+      background: var(--c__primary);
 
       &--arrow-white {
         display: none;

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -2,6 +2,8 @@ import * as React from "react";
 import PropTypes from "prop-types";
 import { Link } from "gatsby";
 
+import Icon from "../Icon";
+
 // Styles.
 import "./Button.css";
 
@@ -36,17 +38,9 @@ const Button = ({
       }`}
       {...props}
     >
-      {startIcon && (
-        <span
-          className={`Button__icon Button__icon--start Button__icon--${startIcon}`}
-        />
-      )}
+      {startIcon && <Icon type={startIcon} align="start" />}
       <span className="Button__body">{children}</span>
-      {endIcon && (
-        <span
-          className={`Button__icon Button__icon--end Button__icon--${endIcon}`}
-        />
-      )}
+      {endIcon && <Icon type={endIcon} align="end" />}
     </Tag>
   );
 };

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -38,9 +38,9 @@ const Button = ({
       }`}
       {...props}
     >
-      {startIcon && <Icon type={startIcon} align="start" />}
+      {startIcon && <Icon type={startIcon} />}
       <span className="Button__body">{children}</span>
-      {endIcon && <Icon type={endIcon} align="end" />}
+      {endIcon && <Icon type={endIcon} />}
     </Tag>
   );
 };

--- a/src/components/Footer/Footer.css
+++ b/src/components/Footer/Footer.css
@@ -53,6 +53,10 @@
     .Button {
       justify-content: center;
 
+      .Icon {
+        background: #3f51b5;
+      }
+
       + .Button {
         margin-left: 0;
       }

--- a/src/components/Icon/Icon.css
+++ b/src/components/Icon/Icon.css
@@ -22,22 +22,18 @@
   width: var(--icon-size);
 
   &--people {
-    background: var(--c__primary);
     mask-image: url("../../images/icons/people.svg");
   }
 
   &--institutions {
-    background: var(--c__primary);
     mask-image: url("../../images/icons/institutions.svg");
   }
 
   &--foreign {
-    background: var(--c__primary);
     mask-image: url("../../images/icons/web.svg");
   }
 
   &--house {
-    background: var(--c__primary);
     mask-image: url("../../images/icons/house.svg");
   }
 }

--- a/src/components/Icon/Icon.css
+++ b/src/components/Icon/Icon.css
@@ -1,4 +1,6 @@
 .Icon {
+  --icon-margin: 10px;
+
   &--small {
     --icon-size: 24px;
   }
@@ -21,14 +23,16 @@
   position: relative;
   width: var(--icon-size);
 
+  /* Alignment */
   &--start {
-    margin-right: 10px;
+    margin-right: var(--icon-margin);
   }
 
   &--end {
-    margin-left: 10px;
+    margin-left: var(--icon-margin);
   }
 
+  /* Icon Types */
   &--people {
     mask-image: url("../../images/icons/people.svg");
   }

--- a/src/components/Icon/Icon.css
+++ b/src/components/Icon/Icon.css
@@ -1,14 +1,25 @@
 .Icon {
+  &--small {
+    --icon-size: 24px;
+  }
+
+  &--medium {
+    --icon-size: 36px;
+  }
+
+  &--large {
+    --icon-size: 48px;
+  }
+
   content: "";
-  display: block;
   display: inline-block;
-  height: 24px;
+  height: var(--icon-size);
   margin-right: 10px;
   mask-position: center;
   mask-repeat: no-repeat;
   mask-size: contain;
   position: relative;
-  width: 24px;
+  width: var(--icon-size);
 
   &--people {
     background: var(--c__primary);

--- a/src/components/Icon/Icon.css
+++ b/src/components/Icon/Icon.css
@@ -23,13 +23,19 @@
   position: relative;
   width: var(--icon-size);
 
-  /* Alignment */
-  &--start {
-    margin-right: var(--icon-margin);
+  .Button > & {
+    &:first-child {
+      margin-right: var(--icon-margin);
+    }
+
+    &:last-child {
+      margin-left: var(--icon-margin);
+    }
   }
 
-  &--end {
-    margin-left: var(--icon-margin);
+  .SlidingNavigation__item > &,
+  .TitledSection__title > & {
+    margin-right: var(--icon-margin);
   }
 
   /* Icon Types */

--- a/src/components/Icon/Icon.css
+++ b/src/components/Icon/Icon.css
@@ -11,15 +11,23 @@
     --icon-size: 48px;
   }
 
+  background: #fff;
   content: "";
   display: inline-block;
   height: var(--icon-size);
-  margin-right: 10px;
   mask-position: center;
   mask-repeat: no-repeat;
   mask-size: contain;
   position: relative;
   width: var(--icon-size);
+
+  &--start {
+    margin-right: 10px;
+  }
+
+  &--end {
+    margin-left: 10px;
+  }
 
   &--people {
     mask-image: url("../../images/icons/people.svg");
@@ -35,5 +43,82 @@
 
   &--house {
     mask-image: url("../../images/icons/house.svg");
+  }
+
+  &--donate {
+    mask-image: url("../../images/icons/donate.svg");
+  }
+
+  &--volunteer {
+    mask-image: url("../../images/icons/volunteer.svg");
+  }
+
+  &--arrow-white {
+    mask-image: url("../../images/icons/arrow-white.svg");
+  }
+
+  &--arrow-blue {
+    background: #3f51b5;
+    mask-image: url("../../images/icons/arrow-blue.svg");
+  }
+
+  &--edit {
+    mask-image: url("../../images/icons/edit.svg");
+  }
+
+  &--brain {
+    mask-image: url("../../images/icons/brain.svg");
+  }
+
+  &--briefcase {
+    mask-image: url("../../images/icons/briefcase.svg");
+  }
+
+  &--building-columns {
+    mask-image: url("../../images/icons/building-columns.svg");
+  }
+
+  &--bus-simple {
+    mask-image: url("../../images/icons/bus-simple.svg");
+  }
+
+  &--child-reaching {
+    mask-image: url("../../images/icons/child-reaching.svg");
+  }
+
+  &--coins {
+    mask-image: url("../../images/icons/coins.svg");
+  }
+
+  &--hands-holding-heart {
+    mask-image: url("../../images/icons/hands-holding-heart.svg");
+  }
+
+  &--key-skeleton {
+    mask-image: url("../../images/icons/key-skeleton.svg");
+  }
+
+  &--mobile-screen-button {
+    mask-image: url("../../images/icons/mobile-screen-button.svg");
+  }
+
+  &--parachute-box {
+    mask-image: url("../../images/icons/parachute-box.svg");
+  }
+
+  &--paw {
+    mask-image: url("../../images/icons/paw.svg");
+  }
+
+  &--phone {
+    mask-image: url("../../images/icons/phone.svg");
+  }
+
+  &--suitcase-medical {
+    mask-image: url("../../images/icons/suitcase-medical.svg");
+  }
+
+  &--user-police {
+    mask-image: url("../../images/icons/user-police.svg");
   }
 }

--- a/src/components/Icon/Icon.css
+++ b/src/components/Icon/Icon.css
@@ -13,7 +13,7 @@
     --icon-size: 48px;
   }
 
-  background: #fff;
+  background: currentcolor;
   content: "";
   display: inline-block;
   height: var(--icon-size);
@@ -64,6 +64,7 @@
   }
 
   &--arrow-white {
+    background: #fff;
     mask-image: url("../../images/icons/arrow-white.svg");
   }
 

--- a/src/components/Icon/Icon.js
+++ b/src/components/Icon/Icon.js
@@ -3,10 +3,10 @@ import PropTypes from "prop-types";
 
 import "./Icon.css";
 
-const Icon = ({ type, size = `small`, align = `start`, className = `` }) => {
+const Icon = ({ type, className = ``, align = `start`, size = `small` }) => {
   return (
     <span
-      className={`Icon ${className} Icon--${align} Icon--${size} Icon--${type}`}
+      className={`Icon Icon--${type} ${className} Icon--${align} Icon--${size}`}
     />
   );
 };

--- a/src/components/Icon/Icon.js
+++ b/src/components/Icon/Icon.js
@@ -3,13 +3,19 @@ import PropTypes from "prop-types";
 
 import "./Icon.css";
 
-const Icon = ({ type, size = `small` }) => {
-  return <span className={`Icon Icon--${size} Icon--${type}`} />;
+const Icon = ({ type, size = `small`, align = `start`, className = `` }) => {
+  return (
+    <span
+      className={`Icon ${className} Icon--${align} Icon--${size} Icon--${type}`}
+    />
+  );
 };
 
 Icon.propTypes = {
   type: PropTypes.string.isRequired,
   size: PropTypes.string,
+  className: PropTypes.string,
+  align: PropTypes.string,
 };
 
 export default Icon;

--- a/src/components/Icon/Icon.js
+++ b/src/components/Icon/Icon.js
@@ -3,19 +3,14 @@ import PropTypes from "prop-types";
 
 import "./Icon.css";
 
-const Icon = ({ type, className = ``, align = `start`, size = `small` }) => {
-  return (
-    <span
-      className={`Icon Icon--${type} ${className} Icon--${align} Icon--${size}`}
-    />
-  );
+const Icon = ({ type, className = ``, size = `small` }) => {
+  return <span className={`Icon Icon--${type} ${className} Icon--${size}`} />;
 };
 
 Icon.propTypes = {
   type: PropTypes.string.isRequired,
   size: PropTypes.string,
   className: PropTypes.string,
-  align: PropTypes.string,
 };
 
 export default Icon;

--- a/src/components/Icon/Icon.js
+++ b/src/components/Icon/Icon.js
@@ -3,12 +3,13 @@ import PropTypes from "prop-types";
 
 import "./Icon.css";
 
-const Icon = ({ type }) => {
-  return <span className={`Icon Icon--${type}`} />;
+const Icon = ({ type, size = `small` }) => {
+  return <span className={`Icon Icon--${size} Icon--${type}`} />;
 };
 
 Icon.propTypes = {
-  type: PropTypes.string,
+  type: PropTypes.string.isRequired,
+  size: PropTypes.string,
 };
 
 export default Icon;

--- a/src/components/Icon/Icon.js
+++ b/src/components/Icon/Icon.js
@@ -1,10 +1,18 @@
 import * as React from "react";
 import PropTypes from "prop-types";
+import classNames from "classnames";
 
 import "./Icon.css";
 
-const Icon = ({ type, className = ``, size = `small` }) => {
-  return <span className={`Icon Icon--${type} ${className} Icon--${size}`} />;
+const Icon = ({ type, className, size = `small` }) => {
+  return (
+    <span
+      className={classNames(`Icon`, className, {
+        [`Icon--${type}`]: type,
+        [`Icon--${size}`]: size,
+      })}
+    />
+  );
 };
 
 Icon.propTypes = {

--- a/src/components/Icon/Icon.stories.js
+++ b/src/components/Icon/Icon.stories.js
@@ -42,11 +42,17 @@ export default {
 const Template = (args) => {
   return <Icon {...args} />;
 };
-
 export const Small = Template.bind({});
 Small.args = {
   type: `house`,
   size: `small`,
+};
+
+Small.parameters = {
+  design: {
+    type: `figma`,
+    url: `https://www.figma.com/file/SbHEfVWgFSozSl1m5oJdmd/Suukraina.lt?node-id=51%3A12590`,
+  },
 };
 
 export const Medium = Template.bind({});
@@ -55,8 +61,16 @@ Medium.args = {
   size: `medium`,
 };
 
+Medium.parameters = {
+  ...Small.parameters,
+};
+
 export const Large = Template.bind({});
 Large.args = {
   ...Small.args,
   size: `large`,
+};
+
+Large.parameters = {
+  ...Small.parameters,
 };

--- a/src/components/Icon/Icon.stories.js
+++ b/src/components/Icon/Icon.stories.js
@@ -1,0 +1,62 @@
+import React from "react";
+
+import Icon from "./Icon";
+
+const iconTypes = [
+  `people`,
+  `institutions`,
+  `foreign`,
+  `house`,
+  `donate`,
+  `volunteer`,
+  `arrow-white`,
+  `arrow-blue`,
+  `edit`,
+  `brain`,
+  `briefcase`,
+  `building-columns`,
+  `bus-simple`,
+  `child-reaching`,
+  `coins`,
+  `hands-holding-heart`,
+  `key-skeleton`,
+  `mobile-screen-button`,
+  `parachute-box`,
+  `paw`,
+  `phone`,
+  `suitcase-medical`,
+  `user-police`,
+];
+
+const iconSizes = [`small`, `medium`, `large`];
+
+export default {
+  component: Icon,
+  title: `Components/Icon`,
+  argTypes: {
+    type: { control: { type: `select`, options: iconTypes } },
+    size: { control: { type: `select`, options: iconSizes } },
+  },
+};
+
+const Template = (args) => {
+  return <Icon {...args} />;
+};
+
+export const Small = Template.bind({});
+Small.args = {
+  type: `house`,
+  size: `small`,
+};
+
+export const Medium = Template.bind({});
+Medium.args = {
+  ...Small.args,
+  size: `medium`,
+};
+
+export const Large = Template.bind({});
+Large.args = {
+  ...Small.args,
+  size: `large`,
+};

--- a/src/components/LinkCollection/LinkCollection.css
+++ b/src/components/LinkCollection/LinkCollection.css
@@ -28,18 +28,16 @@
       text-transform: none;
       width: 100%;
 
+      &::after {
+        display: none;
+      }
+
       &:hover,
       &:focus {
         color: var(--c__secondary);
 
-        .Button__icon {
-          &::before {
-            background-color: var(--c__secondary);
-          }
-        }
-
-        &::after {
-          display: none;
+        .Icon {
+          background-color: var(--c__secondary);
         }
       }
     }
@@ -69,7 +67,7 @@
       box-shadow: none;
       justify-content: center;
 
-      &__icon {
+      .Icon {
         display: none;
       }
     }

--- a/src/components/LinkCollectionWithImage/LinkCollectionWithImage.css
+++ b/src/components/LinkCollectionWithImage/LinkCollectionWithImage.css
@@ -48,12 +48,10 @@
     padding: 0;
     text-transform: none;
 
-    &__icon {
-      &::before {
-        height: 32px;
-        margin-left: var(--s__main-padding);
-        width: 32px;
-      }
+    .Icon {
+      --icon-size: 32px;
+
+      margin-left: var(--s__main-padding);
     }
 
     &:hover {

--- a/src/components/SlidingNavigation/SlidingNavigation.css
+++ b/src/components/SlidingNavigation/SlidingNavigation.css
@@ -41,7 +41,7 @@
     padding: var(--s__main-padding);
     text-decoration: none;
 
-    > span {
+    .Icon {
       background-color: var(--grey-color);
     }
 
@@ -60,7 +60,7 @@
         z-index: 1;
       }
 
-      > span {
+      .Icon {
         background-color: var(--c__primary);
       }
     }

--- a/src/components/TitledSection/TitledSection.css
+++ b/src/components/TitledSection/TitledSection.css
@@ -19,5 +19,9 @@
     font: inherit;
     margin: 0;
     padding: 0;
+
+    .Icon {
+      background: var(--c__primary);
+    }
   }
 }


### PR DESCRIPTION
# Summary of Changes

1. Add `size` attribute to `<Icon />`
   - small: 24px;
   - medium: 36px;
   - large: 48px;
1. Remove colors styling from `<Icon />`
   - Colors shouldn't really be defined on an icon, unless there's an edge case like `arrow-blue`, but even then I'd like to use one single `arrow` svg instead of two separate and define their coloring depending on the parent, or some other criteria. 
1. Use `<Icon />` component inside of `<Button />`
   - This de-clutters the whole `Button.css` file by a **lot**
1. Update button icon style overwrites because of previous point

# Notes
## Icon size attribute
If a custom size is needed, parent can overwrite with css
#### Example:
```css
.parent {
  .Icon {
    --icon-size: 20rem;
  }
}
```
For more examples see [LinkCollectionWithImage.css](https://github.com/adaptdk/su-ukraina/pull/219/files#diff-8ce0a33d13edcd000f69da21de2f818ee06a200e2081e5d882dd4bfefd24876fR52) and [Button.css](https://github.com/adaptdk/su-ukraina/pull/219/files#diff-4a644cd3b5971253f0854a3197fa58567e7b8969527ad45f3172782cb78056bfR94)
# To test

- [ ] Open up the build preview & production websites
- [ ] Go to various pages and visually compare if there are any differences
- [ ] See if everything works & looks as expected
