### PR TITLE
T000 Events improvements

### DIFF
--- a/src/components/EventCard/EventCard.css
+++ b/src/components/EventCard/EventCard.css
@@ -82,42 +82,13 @@
     align-items: center;
     display: flex;
     margin-bottom: calc(var(--s__unit) * 2);
-  }
 
-  &__icon {
-    margin-right: 10px;
+    .Icon {
+      --icon-size: 16px;
 
-    &::before {
       background: var(--c__primary);
-      content: "";
-      display: block;
-      height: 16px;
-      mask-position: center;
-      mask-repeat: no-repeat;
+      margin-right: 10px;
       mask-size: cover;
-      position: relative;
-      width: 16px;
-    }
-
-    &--calendar {
-      &::before {
-        mask-image: url("../../images/icons/calendar.svg");
-        width: 16px;
-      }
-    }
-
-    &--clock {
-      &::before {
-        mask-image: url("../../images/icons/clock.svg");
-        width: 16px;
-      }
-    }
-
-    &--location {
-      &::before {
-        mask-image: url("../../images/icons/location.svg");
-        width: 12px;
-      }
     }
   }
 

--- a/src/components/EventCard/EventCard.js
+++ b/src/components/EventCard/EventCard.js
@@ -90,7 +90,12 @@ const EventCard = ({
         )}
       </div>
       {url && (
-        <Button endIcon="arrow-blue" color="transparent" href={url}>
+        <Button
+          endIcon="arrow-blue"
+          color="transparent"
+          target="_blank"
+          href={url}
+        >
           Renginio Nuoroda
         </Button>
       )}

--- a/src/components/EventCard/EventCard.js
+++ b/src/components/EventCard/EventCard.js
@@ -6,6 +6,7 @@ import Button from "../../components/Button";
 
 // Styles.
 import "./EventCard.css";
+import Icon from "../Icon";
 
 const EventCard = ({
   className = ``,
@@ -55,7 +56,7 @@ const EventCard = ({
         {organizer && <p className="EventCard__event-organizer">{organizer}</p>}
         {startDate && (
           <div className="EventCard__event-info-wrapper">
-            <div className="EventCard__icon EventCard__icon--calendar" />
+            <Icon type="calendar" />
             <time className="EventCard__event-info-text" dateTime={startDate}>
               {getEventDate(startDate)}
               {endDate &&
@@ -66,7 +67,7 @@ const EventCard = ({
         )}
         {startDate && (
           <div className="EventCard__event-info-wrapper">
-            <div className="EventCard__icon EventCard__icon--clock" />
+            <Icon type="clock" />
             <time className="EventCard__event-info-text" dateTime={startDate}>
               {getEventTime(startDate)}
               {endDate &&
@@ -77,7 +78,7 @@ const EventCard = ({
         )}
         {location && (
           <div className="EventCard__event-info-wrapper">
-            <div className="EventCard__icon EventCard__icon--location" />
+            <Icon type="location" />
             <p className="EventCard__event-info-text">{location}</p>
           </div>
         )}

--- a/src/components/EventCard/EventCard.js
+++ b/src/components/EventCard/EventCard.js
@@ -94,6 +94,7 @@ const EventCard = ({
           endIcon="arrow-blue"
           color="transparent"
           target="_blank"
+          rel="noopener"
           href={url}
         >
           Renginio Nuoroda

--- a/src/components/EventCard/EventCard.js
+++ b/src/components/EventCard/EventCard.js
@@ -3,10 +3,10 @@ import PropTypes from "prop-types";
 
 // Components.
 import Button from "../../components/Button";
+import Icon from "../Icon";
 
 // Styles.
 import "./EventCard.css";
-import Icon from "../Icon";
 
 const EventCard = ({
   className = ``,

--- a/src/components/Icon/Icon.css
+++ b/src/components/Icon/Icon.css
@@ -132,4 +132,17 @@
   &--user-police {
     mask-image: url("../../images/icons/user-police.svg");
   }
+
+  &--calendar {
+    mask-image: url("../../images/icons/calendar.svg");
+  }
+
+  &--clock {
+    mask-image: url("../../images/icons/clock.svg");
+  }
+
+  &--location {
+    mask-image: url("../../images/icons/location.svg");
+    width: calc(var(--icon-size) / 4 * 3);
+  }
 }

--- a/src/pages/renginiai.js
+++ b/src/pages/renginiai.js
@@ -41,11 +41,15 @@ const Page = ({ data, pageContext }) => {
     if (event.endDate) {
       const endDate = new Date(event.endDate);
       if (currentDate > endDate) {
-        previousEvents.push(event);
-      } else upcomingEvents.push(event);
+        previousEvents.unshift(event);
+      } else {
+        upcomingEvents.push(event);
+      }
     } else if (currentDate > startDate) {
-      previousEvents.push(event);
-    } else upcomingEvents.push(event);
+      previousEvents.unshift(event);
+    } else {
+      upcomingEvents.push(event);
+    }
   });
 
   return (


### PR DESCRIPTION
<!-- If needed, link to design -->

# Summary of Changes

1. Reverse the sort order of `previousEvents`
2. Use the `<Icon />` component in `<EventCard />`
3. Add `target="_blank"` and `rel="noopener"` to `Renginio Nuoroda` button

# Notes

- Previously it didn't make sense that you had to scroll all the way to the bottom to see an event that ended yesterday.
- The `location` icon's original size is `12 x 16` so have to dynamically calculate it's width with 3:4 aspect ratio

# Screenshots
| Before | ![image](https://user-images.githubusercontent.com/69549795/170203918-4d2e941c-df44-404e-9f46-ffeb7bca7ff1.png) |
| --- | --- |
| After | ![image](https://user-images.githubusercontent.com/69549795/170203714-ffff9f26-d8e2-476a-922d-ed55c85f9b33.png) |

# To test

- [ ] Go to `/renginiai/`
- [ ] See if `Praėję Renginiai` section is sorted as expected
- [ ] See if event cards look as expected
