### PR TITLE
#225 Install gatsby plugin to silence warning

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -185,5 +185,6 @@ module.exports = {
       },
     },
     `create-redirects`,
+    `@mediacurrent/gatsby-plugin-silence-css-order-warning`,
   ],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@fontsource/roboto": "^4.5.5",
+        "@mediacurrent/gatsby-plugin-silence-css-order-warning": "^1.0.0",
         "algoliasearch": "^4.13.0",
         "caniuse-lite": "^1.0.30001327",
         "classnames": "^2.3.1",
@@ -4299,6 +4300,11 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/@mediacurrent/gatsby-plugin-silence-css-order-warning": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@mediacurrent/gatsby-plugin-silence-css-order-warning/-/gatsby-plugin-silence-css-order-warning-1.0.0.tgz",
+      "integrity": "sha512-TiBIncOzH5JtjHxZ43D4KmsZcjaKaGtl4p9+9HbhdDSNC5DcS3KpIJWT0nS0qnSd2QlbDRx44XAkrl4GZpIwTA=="
     },
     "node_modules/@microsoft/fetch-event-source": {
       "version": "2.0.1",
@@ -41059,6 +41065,11 @@
       "resolved": "https://registry.npmjs.org/@mdx-js/util/-/util-1.6.22.tgz",
       "integrity": "sha512-H1rQc1ZOHANWBvPcW+JpGwr+juXSxM8Q8YCkm3GhZd8REu1fHR3z99CErO1p9pkcfcxZnMdIZdIsXkOHY0NilA==",
       "dev": true
+    },
+    "@mediacurrent/gatsby-plugin-silence-css-order-warning": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@mediacurrent/gatsby-plugin-silence-css-order-warning/-/gatsby-plugin-silence-css-order-warning-1.0.0.tgz",
+      "integrity": "sha512-TiBIncOzH5JtjHxZ43D4KmsZcjaKaGtl4p9+9HbhdDSNC5DcS3KpIJWT0nS0qnSd2QlbDRx44XAkrl4GZpIwTA=="
     },
     "@microsoft/fetch-event-source": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@fontsource/roboto": "^4.5.5",
+    "@mediacurrent/gatsby-plugin-silence-css-order-warning": "^1.0.0",
     "algoliasearch": "^4.13.0",
     "caniuse-lite": "^1.0.30001327",
     "classnames": "^2.3.1",


### PR DESCRIPTION
- Issue #225 

<!-- If needed, link to design -->

# Summary of Changes

1. Install `@mediacurrent/gatsby-plugin-silence-css-order-warning`

# Notes

It's a simple plugin that sets the `mini-css-extract-plugin` config's `ignoreOrder` to true. This isn't the ideal solution but at least it cleans up our terminal.

### Caution
Because this plugin silences the warning completely, it may swallow a valid warning of CSS order bundling that you may have in your project.

# To test

- [ ] `npm install`
- [ ] `npm run build`
- [ ] See if any warnings show up in your terminal
