### PR TITLE
#245 Change HeroBanner styles

### DIFF
--- a/src/components/HeroBanner/HeroBanner.css
+++ b/src/components/HeroBanner/HeroBanner.css
@@ -54,38 +54,17 @@
 }
 
 .HeroBanner {
+  display: flex;
+  flex-direction: column;
   grid-area: 1 / 1;
-
-  &__content {
-    margin-bottom: calc(var(--s__unit) * 10);
-    position: relative;
-    z-index: 10;
-
-    @media (min-width: 40rem) {
-      bottom: 0;
-      left: 50%;
-      margin-bottom: 0;
-      position: absolute;
-      transform: translateX(-50%) translateY(40%);
-      width: 100%;
-    }
-  }
+  transform: translateY(10%);
+  z-index: 10;
 
   &__text {
     color: white;
-    margin-bottom: calc(var(--s__unit) * 10);
-    position: relative;
+    flex: 1;
     text-align: left;
     z-index: 10;
-
-    @media (min-width: 40rem) {
-      bottom: 0;
-      left: 50%;
-      margin-bottom: 0;
-      position: absolute;
-      transform: translateX(-50%) translateY(-20%);
-      width: 100%;
-    }
 
     h1 {
       font-size: 3rem;
@@ -97,7 +76,6 @@
     }
 
     @media (min-width: 40rem) {
-      margin-bottom: calc(var(--s__unit) * 20);
       text-align: center;
 
       h1 {
@@ -112,9 +90,19 @@
     }
   }
 
+  &__content {
+    margin-bottom: var(--s__main-padding);
+  }
+
   &__content .Constraint {
     display: flex;
     flex-wrap: wrap;
     justify-content: space-between;
+  }
+
+  @media (min-width: 40rem) {
+    &__content {
+      margin-bottom: 0;
+    }
   }
 }


### PR DESCRIPTION
<!--
Creating the PR.
- Fill the template, add/remove sections as needed.
-->

<!-- Link to issue on Forecast -->

Closes #245 

<!-- If needed, link to design -->

# Summary of Changes

1. Change styles of `.HeroBanner` and it's children

# Notes

- Title's vertical position changed due to it being a flex. Doesn't look too bad, can try to fix if needed?
   - Could look like this with `display: flex` and `align-items: flex-end` on `.HeroBanner__text`
   - ![image](https://user-images.githubusercontent.com/69549795/184350574-8716f46e-35df-4005-9277-15d6278d91fc.png)
- Couldn't fix the CtaCard's overlap on that breakpoint, the cards need a refactor to clean them up.

# Screenshots

## Wide layout
| Before |
| --- |
| ![image](https://user-images.githubusercontent.com/69549795/184350216-ca85af72-9eb8-4ce9-a9c4-bd6fb7db6751.png) |
| After |
| ![image](https://user-images.githubusercontent.com/69549795/184350295-3a0a5d4f-22cf-4912-91f3-f665c65ee95f.png) |

## Narrow layout
| Before | ![image](https://user-images.githubusercontent.com/69549795/184350014-ef3f0fd1-9b8a-41b4-a93f-39c8eebce0fb.png) |
| --- | --- |
| After | ![image](https://user-images.githubusercontent.com/69549795/184350060-7dd406bc-4cc4-47c8-aed2-09989fd661b5.png) |

# To test

- [ ] Go to `/`
- [ ] Change the width of page
- [ ] See if Hero title breaks or overlaps
