### PR TITLE
#277 Replace RU language with EN in HelpSearch

### DIFF
--- a/src/constants/HelpSearch.js
+++ b/src/constants/HelpSearch.js
@@ -1,5 +1,5 @@
 export const LANG_LT = `lt`;
-export const LANG_EN = `ru`;
+export const LANG_EN = `en`;
 export const LANG_UK = `uk`;
 
 export const POSSIBLE_SEARCH_LANGS = [LANG_LT, LANG_EN, LANG_UK];

--- a/src/constants/HelpSearch.js
+++ b/src/constants/HelpSearch.js
@@ -1,94 +1,94 @@
 export const LANG_LT = `lt`;
-export const LANG_RU = `ru`;
+export const LANG_EN = `ru`;
 export const LANG_UK = `uk`;
 
-export const POSSIBLE_SEARCH_LANGS = [LANG_LT, LANG_RU, LANG_UK];
+export const POSSIBLE_SEARCH_LANGS = [LANG_LT, LANG_EN, LANG_UK];
 
 export const TRANSLATIONS = {
   hit: {
     _template: {
       [LANG_LT]: ``,
-      [LANG_RU]: ``,
+      [LANG_EN]: ``,
       [LANG_UK]: ``,
     },
     address: {
       [LANG_LT]: `Adresas`,
-      [LANG_RU]: `Aдрес`,
+      [LANG_EN]: `Address`,
       [LANG_UK]: `Адреса`,
     },
     contacts: {
       [LANG_LT]: `Kontaktai`,
-      [LANG_RU]: `Kонтакты`,
+      [LANG_EN]: `Contacts`,
       [LANG_UK]: `Контакти`,
     },
     purpose: {
       [LANG_LT]: `Aprašymas`,
-      [LANG_RU]: `Дополнительная информация`,
+      [LANG_EN]: `Description`,
       [LANG_UK]: `Додаткова інформація`,
     },
     region: {
       [LANG_LT]: `Vieta`,
-      [LANG_RU]: `Место нахождения`,
+      [LANG_EN]: `Location`,
       [LANG_UK]: `Місцезнаходження`,
     },
     workingHours: {
       [LANG_LT]: `Darbo laikas`,
-      [LANG_RU]: `Время работы`,
+      [LANG_EN]: `Working hours`,
       [LANG_UK]: `Час роботи`,
     },
   },
   hitsPerPage: {
     [LANG_LT]: `puslapyje`,
-    [LANG_RU]: `в страницу`,
+    [LANG_EN]: `on the page`,
     [LANG_UK]: `у сторінці`,
   },
   langSwitcher: {
     language: {
       [LANG_LT]: `Kalba`,
-      [LANG_RU]: `Язык`,
+      [LANG_EN]: `Language`,
       [LANG_UK]: `Мова`,
     },
   },
   refinements: {
     clearFilters: {
       [LANG_LT]: `Išvalyti filtrus`,
-      [LANG_RU]: `Очистить фильтры`,
+      [LANG_EN]: `Clear filters`,
       [LANG_UK]: `Очистіть фільтри`,
     },
     languages: {
       [LANG_LT]: `Kalba`,
-      [LANG_RU]: `Язык`,
+      [LANG_EN]: `Language`,
       [LANG_UK]: `Мова`,
     },
     region: {
       [LANG_LT]: `Vieta`,
-      [LANG_RU]: `Место нахождения`,
+      [LANG_EN]: `Location`,
       [LANG_UK]: `Місцезнаходження`,
     },
     typeOfHelp: {
       [LANG_LT]: `Pagalbos rūšis`,
-      [LANG_RU]: `Тип помощи`,
+      [LANG_EN]: `Type of aid`,
       [LANG_UK]: `Вид допомоги`,
     },
     panelTitle: {
       [LANG_LT]: `Filtrai`,
-      [LANG_RU]: `Фильтры`,
+      [LANG_EN]: `Filters`,
       [LANG_UK]: `Фільтри`,
     },
     doFilter: {
       [LANG_LT]: `Filtruoti`,
-      [LANG_RU]: `Фильтровать`,
+      [LANG_EN]: `Filter`,
       [LANG_UK]: `Фільтрувати`,
     },
   },
   searchBox: {
     [LANG_LT]: `Paieška`,
-    [LANG_RU]: `Поиск`,
+    [LANG_EN]: `Search`,
     [LANG_UK]: `Пошук`,
   },
   noResults: {
     [LANG_LT]: `Paieškai {query} rezultatų rasti nepavyko.`,
-    [LANG_RU]: `По запросу {query} ничего не нашлось.`,
+    [LANG_EN]: `No search results were found for {query}.`,
     [LANG_UK]: `Не знайдено результатів для {query}.`,
   },
 };


### PR DESCRIPTION
<!--
Creating the PR.
- Fill the template, add/remove sections as needed.
-->

<!-- Link to issue on Forecast -->

Closes #277 

<!-- If needed, link to design -->

# Summary of Changes

1. Replace all entries of `RU` language in `HelpSearch.js` with `EN` language.

# Notes
As @grinkus-adapt mentioned in #277, merging this without having any entries in algolia *will* break stuff. Proceed with caution.
