### PR TITLE
#274 silence mini css extract plugin ignore order

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -100,3 +100,17 @@ exports.createSchemaCustomization = ({ actions }) => {
 
   createTypes(typeDefs);
 };
+
+exports.onCreateWebpackConfig = ({ stage, actions, getConfig }) => {
+  // https://stackoverflow.com/a/63128321/20346883
+  if (stage === `develop` || stage === `build-javascript`) {
+    const config = getConfig();
+    const miniCssExtractPlugin = config.plugins.find(
+      (plugin) => plugin.constructor.name === `MiniCssExtractPlugin`
+    );
+    if (miniCssExtractPlugin) {
+      miniCssExtractPlugin.options.ignoreOrder = true;
+    }
+    actions.replaceWebpackConfig(config);
+  }
+};


### PR DESCRIPTION
<!--
Creating the PR.
- Fill the template, add/remove sections as needed.
-->

<!-- Link to issue on Forecast -->

Closes #274

<!-- If needed, link to design -->

# Summary of Changes

1. Enable `ignoreOrder` for `mini-css-extract-plugin` via Gatsby's webpack config

# Notes

A clean terminal is a happy terminal :)

# Screenshots
![image](https://user-images.githubusercontent.com/69549795/213182104-5defd340-4af4-49de-a492-c79084a27d01.png)

# To test

- [ ] `git checkout 274/css-conflicting-order`
- [ ] `npm run develop` or `npm run build`
- [ ] See if the warnings are still there (they should not)
