### PR TITLE
Add trailing slashes to slug links

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -45,25 +45,7 @@ module.exports = {
       },
     },
     `gatsby-plugin-offline`,
-    {
-      resolve: `gatsby-plugin-sitemap`,
-      options: {
-        query: `
-        {
-          site {
-            siteMetadata {
-              siteUrl
-            }
-          }
-          allSitePage {
-            nodes {
-              path
-            }
-          }
-        }
-        `,
-      },
-    },
+    `gatsby-plugin-sitemap`,
     `gatsby-plugin-netlify`,
     `create-redirects`,
     `@mediacurrent/gatsby-plugin-silence-css-order-warning`,

--- a/src/build-utils/helpers/hooks.js
+++ b/src/build-utils/helpers/hooks.js
@@ -46,23 +46,23 @@ const getPathByLocale = (
 ) => {
   if (locale === `lt-LT`) {
     if (prefix[locale]) {
-      return `${prefix[locale]}/${slug}`;
+      return `${prefix[locale]}/${slug}/`;
     }
-    return slug;
+    return `${slug}/`;
   }
 
   if (locale === `uk-UA`) {
     if (prefix[locale]) {
-      return `ua/${prefix[locale]}/${slug}`;
+      return `ua/${prefix[locale]}/${slug}/`;
     }
-    return `ua/${slug}`;
+    return `ua/${slug}/`;
   }
 
   if (locale === `en-US`) {
     if (prefix[locale]) {
-      return `en/${prefix[locale]}/${slug}`;
+      return `en/${prefix[locale]}/${slug}/`;
     }
-    return `en/${slug}`;
+    return `en/${slug}/`;
   }
 
   // This will break the build and we want that
@@ -81,11 +81,11 @@ const getHomePagePath = (locale) => {
   }
 
   if (locale === `uk-UA`) {
-    return `ua`;
+    return `ua/`;
   }
 
   if (locale === `en-US`) {
-    return `en`;
+    return `en/`;
   }
 
   // This will break the build and we want that

--- a/src/build-utils/pages/faqPage.js
+++ b/src/build-utils/pages/faqPage.js
@@ -42,7 +42,7 @@ const createFaqPages = (result, createPage) => {
       const rootPath = getPathByLocale(locale, faqPage?.slug);
 
       faqPage.categories.forEach((faqCategory) => {
-        const categoryPath = `${rootPath}/${faqCategory.slug}`;
+        const categoryPath = `${rootPath}${faqCategory.slug}/`;
         const categoryId = faqCategory.contentful_id;
 
         createPage({

--- a/src/components/Faq/FaqNav/FaqNav.jsx
+++ b/src/components/Faq/FaqNav/FaqNav.jsx
@@ -10,14 +10,6 @@ const FaqNav = ({ rootPath, categories, pathname }) => {
     return null;
   }
 
-  // @todo: fix this bandaid patch
-  const startingSlashRootPath = rootPath.startsWith(`/`)
-    ? rootPath
-    : `/${rootPath}`;
-  const endingSlashRootPath = startingSlashRootPath.endsWith(`/`)
-    ? startingSlashRootPath
-    : `${startingSlashRootPath}/`;
-
   return (
     <nav className="FaqNav">
       <ul className="FaqNav__list">
@@ -30,7 +22,7 @@ const FaqNav = ({ rootPath, categories, pathname }) => {
                   color="primary"
                   startIcon={category.iconType}
                   endIcon={`arrow-white`}
-                  to={`${endingSlashRootPath}${category.slug}/`}
+                  to={`/${rootPath}${category.slug}/`}
                 >
                   {category.pageHeading}
                 </Button>

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -124,7 +124,7 @@ const Header = ({ noSticky, navigation, currentNodeSlugs }) => {
                   >
                     <Link
                       aria-haspopup={!!item.items}
-                      to={`/${item.slug}`}
+                      to={`/${item.slug}/`}
                       onClick={() => {
                         closeMenuOnSameLink(item.slug);
                       }}
@@ -137,7 +137,7 @@ const Header = ({ noSticky, navigation, currentNodeSlugs }) => {
                           return (
                             <li key={subItem.slug}>
                               <Link
-                                to={`/${subItem.slug}`}
+                                to={`/${subItem.slug}/`}
                                 onClick={() => {
                                   closeMenuOnSameLink(subItem.slug);
                                 }}

--- a/src/components/LanguageSwitch/LanguageSwitch.jsx
+++ b/src/components/LanguageSwitch/LanguageSwitch.jsx
@@ -20,17 +20,17 @@ const LanguageSwitch = ({ currentNodeSlugs }) => {
     switch (goToLang) {
       case `uk-UA`:
         if (currentNodeSlugs?.[`uk-UA`]) {
-          return `/ua/${currentNodeSlugs[`uk-UA`]}`;
+          return `/ua/${currentNodeSlugs[`uk-UA`]}/`;
         }
-        return `/ua`;
+        return `/ua/`;
       case `en-US`:
         if (currentNodeSlugs?.[`en-US`]) {
-          return `/en/${currentNodeSlugs[`en-US`]}`;
+          return `/en/${currentNodeSlugs[`en-US`]}/`;
         }
-        return `/en`;
+        return `/en/`;
       case `lt-LT`:
         if (currentNodeSlugs?.[`lt-LT`]) {
-          return `/${currentNodeSlugs[`lt-LT`]}`;
+          return `/${currentNodeSlugs[`lt-LT`]}/`;
         }
         return `/`;
       default:


### PR DESCRIPTION


<!-- If needed, link to design -->

# Summary of Changes

1. Add trailing slashes to links that come from `slug` field (where we expect a raw slug without wrapped slashes)
2. add trailing slashes to langswitch

# To test

- [ ] Go to site
- [ ] Navigate the site
- [ ] See if any links have missing trailing slashes
